### PR TITLE
Ports the three test cases we had for the rectangular layout

### DIFF
--- a/empress/core.py
+++ b/empress/core.py
@@ -347,7 +347,6 @@ class Empress():
         for node in self.tree.preorder(include_self=True):
             names.append(node.name)
             lengths.append(node.length)
-        print(lengths)
 
         s_ids, f_ids, sid2idxs, fid2idxs, compressed_table = compress_table(
             self.table

--- a/empress/support_files/js/empress.js
+++ b/empress/support_files/js/empress.js
@@ -8,7 +8,7 @@ define([
     "BarplotPanel",
     "util",
     "chroma",
-    "LayoutsUtil"
+    "LayoutsUtil",
 ], function (
     _,
     Camera,
@@ -68,7 +68,7 @@ define([
         featureMetadataColumns,
         tipMetadata,
         intMetadata,
-        canvas,
+        canvas
     ) {
         /**
          * @type {Camera}
@@ -299,18 +299,22 @@ define([
         this._group = new Array(this._tree.size + 1).fill(-1);
     }
 
-    Empress.prototype.layouts = function() {
+    Empress.prototype.layouts = function () {
         var d = new Date();
         console.log("starting layout:", d.getTime());
         var coords = LayoutsUtil.rectangularLayout(this._tree, 4020, 4020);
         var dt = new Date();
         console.log("finished layout:", dt.getTime());
-        console.log(this._tree.numleaves())
+        console.log(this._tree.numleaves());
         for (var i = 1; i < this._tree.size; i++) {
-            this._treeData[i][this._tdToInd["xr"]] = _.isNaN(coords.xCoord[i]) ? 0 : coords.xCoord[i];
-            this._treeData[i][this._tdToInd["yr"]] = _.isNaN(coords.yCoord[i]) ? 1 : coords.yCoord[i];
+            this._treeData[i][this._tdToInd["xr"]] = _.isNaN(coords.xCoord[i])
+                ? 0
+                : coords.xCoord[i];
+            this._treeData[i][this._tdToInd["yr"]] = _.isNaN(coords.yCoord[i])
+                ? 1
+                : coords.yCoord[i];
         }
-    }
+    };
 
     /**
      * Initializes WebGL and then draws the tree

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -6,9 +6,6 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      * y-positions are centered over their descendant tips' positions.
      * x-positions are computed based on nodes' branch lengths.
      *
-     * Following this algorithm, nodes' rectangular layout coordinates are
-     * accessible at [node].xr and [node].yr.
-     *
      * For a simple tree, this layout should look something like:
      *          __
      *      ___|
@@ -31,7 +28,7 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
      * @param {Float} height Height of the canvas where the tree will be
      *                       displayed.
      * @return {Object} Object with xCoords and yCoords properties where the
-     *                   node coordinates are stored in postorder.
+     *                  node coordinates are stored in postorder.
      */
     function rectangularLayout(tree, width, height) {
         // NOTE: This doesn't draw a horizontal line leading to the root "node"

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -1,18 +1,48 @@
-define([
-    "underscore",
-    "VectorOps",
-    "util",
-], function (
-    _,
-    VectorOps,
-    util,
-) {
+define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
+    /**
+     * Rectangular layout.
+     *
+     * In this sort of layout, each tip has a distinct y-position, and parent
+     * y-positions are centered over their descendant tips' positions.
+     * x-positions are computed based on nodes' branch lengths.
+     *
+     * Following this algorithm, nodes' rectangular layout coordinates are
+     * accessible at [node].xr and [node].yr.
+     *
+     * For a simple tree, this layout should look something like:
+     *          __
+     *      ___|
+     *  ___|   |__
+     * |   |___
+     * |    ___
+     * |___|
+     *     |___
+     *
+     * For other resources see:
+     *
+     *  https://rachel53461.wordpress.com/2014/04/20/algorithm-for-drawing-trees/
+     *      Clear explanation of Reingold-Tilford that I used a lot
+     *  https://github.com/qiime/Topiary-Explorer/blob/master/src/topiaryexplorer/TreeVis.java
+     *      Derived from the "Rectangular" layout algorithm code.
+     *
+     * @param {BPTree} tree The tree to generate the coordinates for.
+     * @param {Float} width Width of the canvas where the tree will be
+     *                      displayed.
+     * @param {Float} height Height of the canvas where the tree will be
+     *                       displayed.
+     * @return {Object} Object with xCoords and yCoords properties where the
+     *                   node coordinates are stored in postorder.
+     */
     function rectangularLayout(tree, width, height) {
+        // NOTE: This doesn't draw a horizontal line leading to the root "node"
+        // of the graph. See https://github.com/biocore/empress/issues/141 for
+        // context.
+
         var maxWidth = 0;
         var maxHeight = 0;
         var prevY = 0;
         var xCoord = new Array(tree.size + 1);
-        var yCoord = new Array(tree.size +1);
+        var yCoord = new Array(tree.size + 1);
         // postorder
         for (var i = 1; i <= tree.size; i++) {
             if (tree.isleaf(tree.postorderselect(i))) {
@@ -22,10 +52,13 @@ define([
                     maxHeight = yCoord[i];
                 }
             } else {
+                // Center internal nodes above their children
+                // We could also center them above their tips, but (IMO) this
+                // looks better ;)
                 var sum = 0;
                 var numChild = 0;
                 var child = tree.fchild(tree.postorderselect(i));
-                while(child != 0) {
+                while (child !== 0) {
                     child = tree.postorder(child);
                     sum += yCoord[child];
                     child = tree.nsibling(tree.postorderselect(child));
@@ -38,13 +71,9 @@ define([
         xCoord.fill(0);
 
         // iterates in preorder
-        for (var i = 2; i <= tree.size; i++) {
-            var node = tree.postorder(
-                tree.preorderselect(i)
-            )
-            var parent = tree.postorder(
-                tree.parent(tree.preorderselect(i))
-            )
+        for (i = 2; i <= tree.size; i++) {
+            var node = tree.postorder(tree.preorderselect(i));
+            var parent = tree.postorder(tree.parent(tree.preorderselect(i)));
 
             xCoord[node] = xCoord[parent] + tree.lengths_[i];
             if (maxWidth < xCoord[node]) {
@@ -52,24 +81,46 @@ define([
             }
         }
 
+        // We don't check if max_width == 0 here, because we check when
+        // constructing an Empress tree that it has at least one positive
+        // branch length and no negative branch lengths. (And if this is the
+        // case, then max_width must be > 0.)
         var xScalingFactor = width / maxWidth;
+
+        // Since this will be multiplied by 0 for every node, we can set
+        // this to any real number and get the intended "effect" of keeping
+        // every node's y-coordinate at 0.
         var yScalingFactor = 1;
 
+        // Having a max_height of 0 could actually happen, in the funky case
+        // where the entire tree is a straight line (e.g. A -> B -> C). In
+        // this case our "rectangular layout" drawing places all nodes on
+        // the same y-coordinate (0), resulting in max_height = 0.
+        // ... So, that's why we only do y-scaling if this *isn't* the case.
         if (maxHeight > 0) {
             yScalingFactor = height / maxHeight;
         }
 
-        for (var i = 1; i <= tree.size; i++) {
+        for (i = 1; i <= tree.size; i++) {
             xCoord[i] *= xScalingFactor;
             yCoord[i] *= yScalingFactor;
         }
         var rX = xCoord[tree.size];
         var rY = yCoord[tree.size];
-        xCoord = _.map(xCoord, function(val) {return val - rX} )
-        yCoord = _.map(yCoord, function(val) {return val - rY} )
+        xCoord = _.map(xCoord, function (val) {
+            return val - rX;
+        });
+        yCoord = _.map(yCoord, function (val) {
+            return val - rY;
+        });
 
-        return {xCoord: xCoord, yCoord: yCoord}
-    };
+        // We draw each internal node as a vertical line ranging from its
+        // lowest child y-position to its highest child y-position, and then
+        // draw horizontal lines from this line to all of its child nodes
+        // (where the length of the horizontal line is proportional to the node
+        // length in question).
+        return { xCoord: xCoord, yCoord: yCoord };
+    }
 
-    return {rectangularLayout: rectangularLayout};
+    return { rectangularLayout: rectangularLayout };
 });

--- a/empress/support_files/js/layouts-util.js
+++ b/empress/support_files/js/layouts-util.js
@@ -41,8 +41,9 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
         var maxWidth = 0;
         var maxHeight = 0;
         var prevY = 0;
-        var xCoord = new Array(tree.size + 1);
-        var yCoord = new Array(tree.size + 1);
+        var xCoord = new Array(tree.size + 1).fill(0);
+        var yCoord = new Array(tree.size + 1).fill(0);
+
         // postorder
         for (var i = 1; i <= tree.size; i++) {
             if (tree.isleaf(tree.postorderselect(i))) {
@@ -67,8 +68,6 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
                 yCoord[i] = sum / numChild;
             }
         }
-
-        xCoord.fill(0);
 
         // iterates in preorder
         for (i = 2; i <= tree.size; i++) {
@@ -105,14 +104,15 @@ define(["underscore", "VectorOps", "util"], function (_, VectorOps, util) {
             xCoord[i] *= xScalingFactor;
             yCoord[i] *= yScalingFactor;
         }
+
         var rX = xCoord[tree.size];
         var rY = yCoord[tree.size];
-        xCoord = _.map(xCoord, function (val) {
-            return val - rX;
-        });
-        yCoord = _.map(yCoord, function (val) {
-            return val - rY;
-        });
+
+        // skip the first element since the tree is zero-indexed
+        for (i = 1; i <= tree.size; i++) {
+            xCoord[i] -= rX;
+            yCoord[i] -= rY;
+        }
 
         // We draw each internal node as a vertical line ranging from its
         // lowest child y-position to its highest child y-position, and then

--- a/tests/index.html
+++ b/tests/index.html
@@ -91,6 +91,7 @@
           'VectorOps' : './support_files/js/vector-ops',
           'CanvasEvents' : './support_files/js/canvas-events',
           'SelectedNodeMenu' : './support_files/js/select-node-menu',
+          'LayoutsUtil' : './support_files/js/layouts-util',
 
           /* test paths */
           'testBPTree' : './../tests/test-bp-tree',
@@ -103,7 +104,8 @@
           'testVectorOps' : './../tests/test-vector-ops',
           'testEmpress' : './../tests/test-empress',
           'testExport': './../tests/test-export',
-          'testAnimationHandler': './../tests/test-animation-panel-handler'
+          'testAnimationHandler': './../tests/test-animation-panel-handler',
+          'testLayoutsUtil': './../tests/test-layouts-util'
         }
     });
 
@@ -125,6 +127,7 @@
          'util',
          'Empress',
          'Legend',
+         'LayoutsUtil',
          'testBPTree',
          'testByteTree',
          'testBIOMTable',
@@ -135,7 +138,8 @@
          'testVectorOps',
          'testEmpress',
          'testAnimationHandler',
-         'testExport'
+         'testExport',
+         'testLayoutsUtil'
          ],
 
         // start tests
@@ -157,6 +161,7 @@
           util,
           Empress,
           Legend,
+          LayoutsUtil,
           testBPTree,
           testByteTree,
           testCamera,
@@ -166,7 +171,8 @@
           testVectorOps,
           testEmpress,
           testAnimationHandler,
-          testExport
+          testExport,
+          testLayoutUtils
         ) {
             $(document).ready(function() {
                 QUnit.start();

--- a/tests/test-layouts-util.js
+++ b/tests/test-layouts-util.js
@@ -1,0 +1,108 @@
+require(["jquery", "ByteArray", "BPTree", "LayoutsUtil"], function (
+    $,
+    ByteArray,
+    BPTree,
+    LayoutsUtil
+) {
+    $(document).ready(function () {
+        module("Test layout utils", {
+            setup: function () {
+                this.tree = new BPTree(
+                    new Uint8Array([
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                    ]),
+                    ["", "i", "g", "f", "a", "e", "b", "h", "c", "d"],
+                    [null, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 1.0, 3.0],
+                    null
+                );
+
+                this.straightLineTree = new BPTree(
+                    new Uint8Array([1, 1, 1, 0, 0, 0]),
+                    ["", "root", "a", "b"],
+                    ["", 100.0, 1.0, 2.0],
+                    null
+                );
+
+                this.noRootLength = new BPTree(
+                    new Uint8Array([1, 1, 1, 0, 0, 0]),
+                    ["", "root", "a", "b"],
+                    ["", null, 1.0, 2.0],
+                    null
+                );
+            },
+
+            teardown: function () {
+                this.bpArray = null;
+                this.tree = null;
+                this.straightLineTree = null;
+                this.noRootLength = null;
+            },
+        });
+
+        test("Test rectangular layout", function () {
+            var obs = LayoutsUtil.rectangularLayout(this.tree, 500, 500);
+
+            var exp = {
+                xCoord: [0, 300, 400, 200, 300, 100, 300, 500, 200, 0.0],
+                yCoord: [
+                    0,
+                    -296.875,
+                    -171.875,
+                    -234.375,
+                    -46.875,
+                    -140.625,
+                    78.125,
+                    203.125,
+                    140.625,
+                    0.0,
+                ],
+            };
+            deepEqual(obs, exp);
+        });
+
+        test("Test straightline tree rectangular layout", function () {
+            var obs = LayoutsUtil.rectangularLayout(
+                this.straightLineTree,
+                100,
+                100
+            );
+
+            var exp = {
+                xCoord: [0, 100, 100 / 3, 0],
+                yCoord: [0, 0, 0, 0],
+            };
+            deepEqual(obs, exp);
+        });
+
+        test("Test missing root length rectangular layout", function () {
+            var obs = LayoutsUtil.rectangularLayout(
+                this.noRootLength,
+                100,
+                100
+            );
+
+            var exp = {
+                xCoord: [0, 100, 100 / 3, 0],
+                yCoord: [0, 0, 0, 0],
+            };
+            deepEqual(obs, exp);
+        });
+    });
+});


### PR DESCRIPTION
I think there's a few things that might be missing but this in principle should be a good start. I also added the comments from the Python version.

For posterity, this is the Python code I used to port the trees (might be helpful for porting other tests):

```python
from skbio import TreeNode
from bp import parse_newick

f = '((b:2)a:1)root:100;'
names, lengths = [""], [""]

t =  TreeNode.read([f])
for n in t.preorder(include_self=True): 
    names.append(n.name) 
    lengths.append(n.length) 

print(names, lengths, parse_newick(f).B.tolist())

```

Submitting this to @kwcantrell's branch for now. CC @fedarko.